### PR TITLE
Fix list of active authorizations not answered

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,5 @@
+- Bug fix: Only trigger authorizations redirector for child authorization if root authorization is active #UL-ISEG-1954
+
 4.12.2 (16-07-2021)
 - Improvement: Remove checkDebts condition from domain, this should be an enrolment process configuration
 

--- a/src/main/java/org/fenixedu/academicextensions/domain/person/dataShare/DataShareAuthorization.java
+++ b/src/main/java/org/fenixedu/academicextensions/domain/person/dataShare/DataShareAuthorization.java
@@ -120,9 +120,13 @@ public class DataShareAuthorization extends DataShareAuthorization_Base {
     }
 
     static public Set<DataShareAuthorizationType> findActiveAuthorizationTypes(final Person person) {
-        return Bennu.getInstance().getDataShareAuthorizationTypeSet().stream()
-                .filter(type -> type.isActive() && Group.parse(type.getGroupExpression()).isMember(person.getUser()))
-                .collect(Collectors.toSet());
+        return Bennu.getInstance().getDataShareAuthorizationTypeSet().stream().filter(type -> {
+            DataShareAuthorizationType authorizationTypeParent = type.getDataShareAuthorizationTypeParent();
+            if (authorizationTypeParent != null && !authorizationTypeParent.isActive()) {
+                return false;
+            }
+            return type.isActive() && Group.parse(type.getGroupExpression()).isMember(person.getUser());
+        }).collect(Collectors.toSet());
     }
 
     static public Set<DataShareAuthorizationType> findActiveAuthorizationTypesNotAnswered(final Person person) {

--- a/src/main/java/org/fenixedu/academicextensions/domain/person/dataShare/DataShareAuthorizationType.java
+++ b/src/main/java/org/fenixedu/academicextensions/domain/person/dataShare/DataShareAuthorizationType.java
@@ -123,6 +123,12 @@ public class DataShareAuthorizationType extends DataShareAuthorizationType_Base 
         return found.size() == 1 ? found.iterator().next() : null;
     }
 
+    @Override
+    public void setActive(boolean active) {
+        super.setActive(active);
+        getDataShareAuthorizationTypeChildrenSet().forEach(c -> c.setActive(active));
+    }
+
     public boolean isActive() {
         return super.getActive();
     }


### PR DESCRIPTION
Only trigger authorizations redirector for child authorization if root
authorization is active.

Basicaly the redirect was being triggered by an active child
authorization although the root authorzation isn't active.
This made the users go to the authorization screen and unable to
answer the authorizations because of the inactive root authorization.

This fixes #UL-ISEG-1954 and related