### PR TITLE
Performance improves in guava caches in CompeteceCourseServices

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,5 @@
+- Improvement: Performance improvement to handle heavly load in CompeteceCourseServices [#qubIT-Fenix-5358]
+
 4.33.0 (17-06-2024)
 - Improvement: Performs release for jdk 17 [#qubIT-Omnis-4737]
 


### PR DESCRIPTION
Several improvements in the caches in competence course services:

1. CACHE_COMPETENCE_CURRICULARS has no expiration configured not invalidation so switching it into a ConcurrentHashMap

2. CACHE_APPROVALS and CACHE_SCPS were being concurrenly accessed by multiple students, but they are caches per student, so we are first creating concurrentHashMaps to create partition in caches allowing a better flow regarding cache contention access in high concurrency scenarios.

Relates with: #qubIT-Fenix-5358